### PR TITLE
Remove TypeVar

### DIFF
--- a/cppython_core/plugin_schema/generator.py
+++ b/cppython_core/plugin_schema/generator.py
@@ -1,7 +1,7 @@
 """Generator data plugin definitions"""
 
 from abc import abstractmethod
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from pydantic.types import DirectoryPath
 
@@ -67,6 +67,3 @@ class Generator(DataPlugin, SyncConsumer, Protocol):
             The supported features
         """
         raise NotImplementedError
-
-
-GeneratorT = TypeVar("GeneratorT", bound=Generator)

--- a/cppython_core/plugin_schema/provider.py
+++ b/cppython_core/plugin_schema/provider.py
@@ -1,7 +1,7 @@
 """Provider data plugin definitions"""
 
 from abc import abstractmethod
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from pydantic.types import DirectoryPath
 
@@ -85,6 +85,3 @@ class Provider(DataPlugin, SyncProducer, Protocol):
     def update(self) -> None:
         """Called when dependencies need to be updated and written to the lock file."""
         raise NotImplementedError
-
-
-ProviderT = TypeVar("ProviderT", bound=Provider)

--- a/cppython_core/plugin_schema/scm.py
+++ b/cppython_core/plugin_schema/scm.py
@@ -1,7 +1,7 @@
 """Version control data plugin definitions"""
 
 from abc import abstractmethod
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from pydantic import DirectoryPath, Field
 
@@ -57,6 +57,3 @@ class SCM(Plugin, Protocol):
         Returns:
             Returns the project description, or none if unavailable
         """
-
-
-SCMT = TypeVar("SCMT", bound=SCM)

--- a/cppython_core/schema.py
+++ b/cppython_core/schema.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any, NewType, Protocol, TypeVar
+from typing import Any, NewType, Protocol
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic.types import DirectoryPath, FilePath
@@ -13,10 +13,6 @@ class CPPythonModel(BaseModel):
     """The base model to use for all CPPython models"""
 
     model_config = {"populate_by_name": False}
-
-
-ModelT = TypeVar("ModelT", bound=CPPythonModel)
-
 
 class ProjectData(CPPythonModel, extra="forbid"):
     """Resolved data of 'ProjectConfiguration'"""
@@ -165,10 +161,6 @@ class SyncData(CPPythonModel):
 
     provider_name: PluginName
 
-
-SyncDataT = TypeVar("SyncDataT", bound=SyncData)
-
-
 class SupportedFeatures(CPPythonModel):
     """Plugin feature support"""
 
@@ -223,10 +215,6 @@ class Plugin(Protocol):
         """
         raise NotImplementedError
 
-
-PluginT = TypeVar("PluginT", bound=Plugin)
-
-
 class DataPluginGroupData(PluginGroupData):
     """Data plugin group data"""
 
@@ -272,10 +260,6 @@ class DataPlugin(Plugin, Protocol):
         Args:
             directory: The directory to download any extra tooling to
         """
-
-
-DataPluginT = TypeVar("DataPluginT", bound=DataPlugin)
-
 
 class CPPythonGlobalConfiguration(CPPythonModel, extra="forbid"):
     """Global data extracted by the tool"""
@@ -345,6 +329,3 @@ class Interface(Protocol):
     def write_configuration(self) -> None:
         """Called when CPPython requires the interface to write out configuration changes"""
         raise NotImplementedError
-
-
-InterfaceT = TypeVar("InterfaceT", bound=Interface)


### PR DESCRIPTION
ALL TypeVar usage was to support upper bounded types which can now be accomplished with PEP 695